### PR TITLE
Patch stdio error with vscode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "lsp-ai"
-version = "0.5.1"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/lsp-ai/Cargo.toml
+++ b/crates/lsp-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lsp-ai"
-version = "0.6.0"
+version = "0.6.1"
 
 description.workspace = true
 repository.workspace = true

--- a/crates/lsp-ai/src/main.rs
+++ b/crates/lsp-ai/src/main.rs
@@ -65,6 +65,9 @@ struct Args {
     // Whether to use a custom log file
     #[arg(long, default_value_t = false)]
     use_seperate_log_file: bool,
+    // A dummy argument for now
+    #[arg(long, default_value_t = true)]
+    stdio: bool,
 }
 
 fn create_log_file(base_path: &Path) -> anyhow::Result<fs::File> {


### PR DESCRIPTION
Add `stdio` as a dummy command line argument for now.