### PR TITLE
Simplified nix flake for build, dev shell, and cached build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 lsp-ai.log
 .vsix
 lsp-ai-chat.md
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1726463316,
+        "narHash": "sha256-gI9kkaH0ZjakJOKrdjaI/VbaMEo9qBbSUl93DnU7f4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "99dc8785f6a0adac95f5e2ab05cc2e1bf666d172",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1726712837,
+        "narHash": "sha256-Ob7DNyHKtOQpWetmNj/V+OgMkGXh6Ep1dNa6AN/4sSI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6283b1d6ca31fa320ecee82806123e773b2ff993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "LSP-AI: An open-source language server for AI-powered functionality";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { 
+          inherit system overlays; 
+          config.allowUnfree = true;
+        };
+        rustVersion = pkgs.rust-bin.stable.latest.default;
+        
+        commonEnv = {
+          OPENSSL_NO_VENDOR = 1;
+          OPENSSL_DIR = "${pkgs.openssl.dev}";
+          OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+          RUSTFLAGS = "-C target-cpu=native";
+        };
+
+        commonBuildInputs = with pkgs; [ 
+          openssl 
+          openssl.dev
+          zlib
+        ];
+
+        commonNativeBuildInputs = with pkgs; [ 
+          pkg-config 
+          cmake 
+          rustVersion 
+          perl
+        ];
+
+      in rec {
+        packages = rec {
+          default = pkgs.rustPlatform.buildRustPackage ({
+            pname = "lsp-ai";
+            version = "0.7.0";
+
+            src = ./.;
+
+            cargoLock = {
+              lockFile = ./Cargo.lock;
+              allowBuiltinFetchGit = true;
+            };
+
+            nativeBuildInputs = commonNativeBuildInputs;
+            buildInputs = commonBuildInputs;
+
+            buildFeatures = [ "all" ];
+
+            doCheck = false;
+
+            meta = with pkgs.lib; {
+              description = "An open-source language server that serves as a backend for AI-powered functionality";
+              homepage = "https://github.com/SilasMarvin/lsp-ai";
+              license = licenses.mit;
+              maintainers = [ /* Add maintainers here */ ];
+            };
+          } // commonEnv);
+
+          devPackage = default.overrideAttrs (oldAttrs: {
+            name = "lsp-ai-dev";
+            
+            buildPhase = ''
+              export CARGO_HOME="/tmp/.cargo"
+              export RUSTUP_HOME="/tmp/.rustup"
+              cargo build --features all
+            '';
+
+            installPhase = ''
+              mkdir -p $out/bin
+              cp target/debug/lsp-ai $out/bin/
+            '';
+          });
+        };
+
+        devShells.default = pkgs.mkShell ({
+          inputsFrom = [ packages.default ];
+          packages = with pkgs; [
+            rust-analyzer
+            clippy
+            rustfmt
+          ];
+          
+          shellHook = ''
+            export CARGO_HOME="/tmp/.cargo"
+            export RUSTUP_HOME="/tmp/.rustup"
+          '';
+        } // commonEnv);
+      }
+    );
+}


### PR DESCRIPTION
I see #60. Honestly not sure which method is better at the moment. This PR allows local building with `nix build` and a development shell with `nix develop`. Ideally adding an entry to nixpkgs might solve #60 and #32 since it will be built into the eco-system. Open to discussion. Still learning nix myself.