### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "lsp-ai"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
lsp-ai version did not get bumped in lock file. Breaks CI checks that look for inconsistencies between toml file and lock files.

Should be merged into releases and mainline so systems that build against your release branch will also get updated. 